### PR TITLE
Add Vagrant for easy reproducible server dev environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ debug.log
 settings.py
 uploads/recap_config.py
 ia_upload_script.sh
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,113 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "precise32"
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network :forwarded_port, guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network :private_network, ip: "10.42.42.42"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network :public_network
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  config.vm.provision :shell, :path => "bootstrap.sh"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider :virtualbox do |vb|
+  #   # Don't boot with headless mode
+  #   vb.gui = true
+  #
+  #   # Use VBoxManage to customize the VM. For example to change memory:
+  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
+  # end
+  #
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+  # Enable provisioning with Puppet stand alone.  Puppet manifests
+  # are contained in a directory path relative to this Vagrantfile.
+  # You will need to create the manifests directory and a manifest in
+  # the file base.pp in the manifests_path directory.
+  #
+  # An example Puppet manifest to provision the message of the day:
+  #
+  # # group { "puppet":
+  # #   ensure => "present",
+  # # }
+  # #
+  # # File { owner => 0, group => 0, mode => 0644 }
+  # #
+  # # file { '/etc/motd':
+  # #   content => "Welcome to your Vagrant-built virtual machine!
+  # #               Managed by Puppet.\n"
+  # # }
+  #
+  # config.vm.provision :puppet do |puppet|
+  #   puppet.manifests_path = "manifests"
+  #   puppet.manifest_file  = "base.pp"
+  # end
+
+  # Enable provisioning with chef solo, specifying a cookbooks path, roles
+  # path, and data_bags path (all relative to this Vagrantfile), and adding
+  # some recipes and/or roles.
+  #
+  # config.vm.provision :chef_solo do |chef|
+  #   chef.cookbooks_path = "../my-recipes/cookbooks"
+  #   chef.roles_path = "../my-recipes/roles"
+  #   chef.data_bags_path = "../my-recipes/data_bags"
+  #   chef.add_recipe "mysql"
+  #   chef.add_role "web"
+  #
+  #   # You may also specify custom JSON attributes:
+  #   chef.json = { :mysql_password => "foo" }
+  # end
+
+  # Enable provisioning with chef server, specifying the chef server URL,
+  # and the path to the validation key (relative to this Vagrantfile).
+  #
+  # The Opscode Platform uses HTTPS. Substitute your organization for
+  # ORGNAME in the URL and validation key.
+  #
+  # If you have your own Chef Server, use the appropriate URL, which may be
+  # HTTP instead of HTTPS depending on your configuration. Also change the
+  # validation key to validation.pem.
+  #
+  # config.vm.provision :chef_client do |chef|
+  #   chef.chef_server_url = "https://api.opscode.com/organizations/ORGNAME"
+  #   chef.validation_key_path = "ORGNAME-validator.pem"
+  # end
+  #
+  # If you're using the Opscode platform, your validator client is
+  # ORGNAME-validator, replacing ORGNAME with your organization name.
+  #
+  # If you have your own Chef Server, the default validation client name is
+  # chef-validator, unless you changed the configuration.
+  #
+  #   chef.validation_client_name = "ORGNAME-validator"
+end

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get -y install python-software-properties
+add-apt-repository -y ppa:fkrull/deadsnakes && apt-get update
+apt-get -y install curl patch mysql-server python-pip libxslt1-dev libxml2-dev libmysqlclient-dev libssl-dev python2.5 python2.5-dev screen
+
+# There is a strange bug in MySQL
+echo "FLUSH PRIVILEGES; DROP USER 'recapper'; FLUSH PRIVILEGES;" | mysql -uroot
+echo "CREATE USER 'recapper'@'localhost' IDENTIFIED BY 'recap';
+CREATE DATABASE IF NOT EXISTS recap_dev;
+GRANT ALL PRIVILEGES ON recap_dev . * TO 'recapper'@'localhost';" | mysql -uroot
+
+# Install virtualenv and create a 2.5 RECAP virtualenv
+pip install virtualenvwrapper
+export WORKON_HOME=~/Envs
+mkdir -p $WORKON_HOME
+source /usr/local/bin/virtualenvwrapper.sh
+mkvirtualenv -p $(which python2.5) RECAP
+
+ln -s /vagrant recap-server
+cd recap-server
+pip install --insecure -r requirements.txt
+
+export PYTHONPATH=/home/vagrant
+python manage.py syncdb
+screen -d -m -S RECAP sh -c 'python manage.py runserver 0.0.0.0:8000; exec bash'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+http://www.djangoproject.com/download/0.96.5/tarball/
+lxml==3.1beta1
+MySQL_python==1.2.4


### PR DESCRIPTION
To start a dev VM do `vagrant up`
You'll have the RECAP server running on 10.42.42.42:8000
Config: Database recap_dev - User recapper - Pass recap
It will run directly your codebase, and log in your debug.log
Access the output of the server from root's screen via `vagrant ssh`

I plan to add also a PhpMyAdmin to the mix.
