### PR TITLE
Small changes to README file.

### DIFF
--- a/README
+++ b/README
@@ -5,20 +5,20 @@ This is the server side of the RECAP platform. See uploads/views.py if you're tr
 Website: http://www.recapthelaw.org
 Contact: info@recapthelaw.org
 
-Copyright 2009-2013 Harlan Yu, Timothy B. Lee, Stephen Schultze, Dhruv Kapadia. (and more to come!)
+Copyright 2009-2014 Harlan Yu, Timothy B. Lee, Stephen Schultze, Dhruv Kapadia. (and more to come!)
 
 License:
-    The RECAP Firefox Extension is free software: you can redistribute it 
+    The RECAP Server is free software: you can redistribute it 
     and/or modify it under the terms of the GNU General Public License as
     published by the Free Software Foundation, either version 3 of the 
     License, or (at your option) any later version.
 
-    The RECAP Firefox Extension is distributed in the hope that it will be
+    The RECAP Server is distributed in the hope that it will be
     useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with the RECAP Firefox Extension.  If not, see: 
+    along with the RECAP Server.  If not, see: 
     http://www.gnu.org/licenses/
 


### PR DESCRIPTION
Update copyright year to 2014. Change license to refer to "RECAP Server"
instead of the "RECAP Firefox Extension".