### PR TITLE
Don't let request URL be unicode, for python 2.7 compatibility

### DIFF
--- a/uploads/InternetArchiveCommon.py
+++ b/uploads/InternetArchiveCommon.py
@@ -109,7 +109,7 @@ def make_pdf_request(filebits, court, casenum, docnum, subdocnum, metadict, make
     bucketname = get_bucketname(court, casenum)
     filename = get_pdfname(court, casenum, docnum, subdocnum)
 
-    storage_path = "%s/%s" % (bucketname, filename)
+    storage_path = ("%s/%s" % (bucketname, filename)).encode('utf-8')
     request = _init_put(storage_path)
 
     # Add the payload


### PR DESCRIPTION
(re-submitting pull request after git weirdness)

So far this is the only change I had to make for Python 2.7 compatibility. It is a change to encode unicode filenames as utf-8, which I believe should be backwards compatible with 2.5, but I'm not sure. Feel free to test out in the dev python 2.5 environment and get back to me.